### PR TITLE
fix exception when showing a terminal window

### DIFF
--- a/lua/nvterm/terminal.lua
+++ b/lua/nvterm/terminal.lua
@@ -107,6 +107,7 @@ nvterm.hide = function(type)
 end
 
 nvterm.show = function(type)
+  terminals = util.verify_terminals(terminals)
   local term = type and get_type_last(type) or terminals.last
   nvterm.show_term(term)
 end


### PR DESCRIPTION
Sometimes `nvterm.show` crashes with an `termutil.lua:33: Expected lua table` exception