### PR TITLE
Better terminal list handling

### DIFF
--- a/lua/nvterm/terminal.lua
+++ b/lua/nvterm/terminal.lua
@@ -7,7 +7,7 @@ local function get_last(list)
   if list then
     return not vim.tbl_isempty(list) and list[#list] or nil
   end
-  return terminals[#terminals] or nil
+  return terminals.list[#terminals.list] or nil
 end
 
 local function get_type(type, list)
@@ -108,7 +108,7 @@ end
 
 nvterm.show = function(type)
   terminals = util.verify_terminals(terminals)
-  local term = type and get_type_last(type) or terminals.last
+  local term = type and get_type_last(type) or get_last()
   nvterm.show_term(term)
 end
 

--- a/lua/nvterm/terminal.lua
+++ b/lua/nvterm/terminal.lua
@@ -7,10 +7,12 @@ local function get_last(list)
   if list then
     return not vim.tbl_isempty(list) and list[#list] or nil
   end
+  terminals = util.verify_terminals(terminals)
   return terminals.list[#terminals.list] or nil
 end
 
 local function get_type(type, list)
+  terminals = util.verify_terminals(terminals)
   list = list or terminals.list
   return vim.tbl_filter(function(t)
     return t.type == type
@@ -18,6 +20,7 @@ local function get_type(type, list)
 end
 
 local function get_still_open()
+  terminals = util.verify_terminals(terminals)
   if not terminals.list then
     return {}
   end
@@ -35,6 +38,7 @@ local function get_type_last(type)
 end
 
 local function get_term(key, value)
+  terminals = util.verify_terminals(terminals)
   -- assumed to be unique, will only return 1 term regardless
   return vim.tbl_filter(function(t)
     return t[key] == value
@@ -42,6 +46,7 @@ local function get_term(key, value)
 end
 
 local create_term_window = function(type)
+  terminals = util.verify_terminals(terminals)
   local existing = terminals.list and #get_type(type, get_still_open()) > 0
   util.execute_type_cmd(type, terminals, existing)
   vim.wo.relativenumber = false
@@ -50,7 +55,6 @@ local create_term_window = function(type)
 end
 
 local ensure_and_send = function(cmd, type)
-  terminals = util.verify_terminals(terminals)
   local function select_term()
     if not type then
       return get_last_still_open() or nvterm.new "horizontal"
@@ -107,7 +111,6 @@ nvterm.hide = function(type)
 end
 
 nvterm.show = function(type)
-  terminals = util.verify_terminals(terminals)
   local term = type and get_type_last(type) or get_last()
   nvterm.show_term(term)
 end
@@ -120,6 +123,7 @@ nvterm.new = function(type)
   a.nvim_win_set_buf(win, buf)
 
   local job_id = vim.fn.termopen(terminals.shell or vim.o.shell)
+  terminals = util.verify_terminals(terminals)
   local id = #terminals.list + 1
   local term = { id = id, win = win, buf = buf, open = true, type = type, job_id = job_id }
   terminals.list[id] = term
@@ -128,7 +132,6 @@ nvterm.new = function(type)
 end
 
 nvterm.toggle = function(type)
-  terminals = util.verify_terminals(terminals)
   local term = get_type_last(type)
 
   if not term then
@@ -170,6 +173,7 @@ nvterm.list_active_terms = function(property)
 end
 
 nvterm.list_terms = function()
+  terminals = util.verify_terminals(terminals)
   return terminals.list
 end
 


### PR DESCRIPTION
The state of the terminal list are often outdated by the time nvterm does things with it, so we should always verify it first. The verification is now done in the lower-level functions, so they are no longer needed in some functions and thus removed.
Also, fixed some outdated(?) references to non-existing tables.