### PR TITLE
Improve documentation: additional functionality example

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,17 +89,23 @@ require("nvterm").setup()
 
 local terminal = require("nvterm.terminal")
 
-local ft_cmds = {
-  python = "python3 " .. vim.fn.expand('%'),
-  ...
-  <your commands here>
-}
 local toggle_modes = {'n', 't'}
 local mappings = {
-  { 'n', '<C-l>', function () require("nvterm.terminal").send(ft_cmds[vim.bo.filetype]) end },
-  { toggle_modes, '<A-h>', function () require("nvterm.terminal").toggle('horizontal') end },
-  { toggle_modes, '<A-v>', function () require("nvterm.terminal").toggle('vertical') end },
-  { toggle_modes, '<A-i>', function () require("nvterm.terminal").toggle('float') end },
+  { 
+    'n',
+    '<C-l>', 
+    function ()
+      local ft_cmds = {
+        python = "python3 " .. vim.fn.expand('%'),
+        ...
+        <your commands here>
+      }
+      terminal.send(ft_cmds[vim.bo.filetype]) 
+    end 
+  },
+  { toggle_modes, '<A-h>', function () terminal.toggle('horizontal') end },
+  { toggle_modes, '<A-v>', function () terminal.toggle('vertical') end },
+  { toggle_modes, '<A-i>', function () terminal.toggle('float') end },
 }
 local opts = { noremap = true, silent = true }
 for _, mapping in ipairs(mappings) do


### PR DESCRIPTION
The current example in the `README.md` regarding additional functionality and how to define commands per filetype has a little drawback with `vim.fn.expand('%')` due the current way to call this function at load time and not when the keymap is being called; more information about: [in this redit post](https://www.reddit.com/r/neovim/comments/vty0ov/neovim_how_to_rexecute_vimfnexpand_every_time_a/)

The current approach in the new example solves this issue.