### PR TITLE
Use terminal variable in sample code

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,10 +96,10 @@ local ft_cmds = {
 }
 local toggle_modes = {'n', 't'}
 local mappings = {
-  { 'n', '<C-l>', function () require("nvterm.terminal").send(ft_cmds[vim.bo.filetype]) end },
-  { toggle_modes, '<A-h>', function () require("nvterm.terminal").toggle('horizontal') end },
-  { toggle_modes, '<A-v>', function () require("nvterm.terminal").toggle('vertical') end },
-  { toggle_modes, '<A-i>', function () require("nvterm.terminal").toggle('float') end },
+  { 'n', '<C-l>', function () terminal.send(ft_cmds[vim.bo.filetype]) end },
+  { toggle_modes, '<A-h>', function () terminal.toggle('horizontal') end },
+  { toggle_modes, '<A-v>', function () terminal.toggle('vertical') end },
+  { toggle_modes, '<A-i>', function () terminal.toggle('float') end },
 }
 local opts = { noremap = true, silent = true }
 for _, mapping in ipairs(mappings) do


### PR DESCRIPTION
The terminal variable was not used in the sample code, so either delete it or use it. 