### PR TITLE
fix keeping terminal size after exiting and reopening

### DIFF
--- a/lua/nvterm/init.lua
+++ b/lua/nvterm/init.lua
@@ -59,9 +59,11 @@ local set_behavior = function(behavior)
   end
   if behavior.close_on_exit then
     vim.api.nvim_create_autocmd({ "TermClose" }, {
-      callback = function()
-        vim.schedule_wrap(vim.api.nvim_input "<CR>")
-      end,
+      callback = vim.schedule_wrap(function()
+        local bufnr = vim.fn.bufnr("%")
+        vim.api.nvim_buf_delete(bufnr, { force = true, unload = true })
+        require("nvterm.terminal").verify_terminals()
+      end),
     })
   end
 

--- a/lua/nvterm/terminal.lua
+++ b/lua/nvterm/terminal.lua
@@ -159,6 +159,10 @@ nvterm.close_all_terms = function()
   end
 end
 
+nvterm.verify_terminals = function()
+  terminals = util.verify_terminals(terminals)
+end
+
 nvterm.list_active_terms = function(property)
   local terms = get_still_open()
   if property then


### PR DESCRIPTION
Before, when I first opened the terminal, it had a height ratio of 0.3 (set by the configuration). But, if I closed and reopened it, the ratio would always change to 0.5. This update makes sure that the terminal keeps the correct ratio even after I exit and reopen it.

https://github.com/NvChad/nvterm/assets/54699919/e70fc307-c20b-496e-8a26-2bf10dd3cb99

